### PR TITLE
Update links to new Github organisation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ twitter_username: talkingtock
 twitter:
   username: talkingtock
 github:
-  username: helena-project
+  username: tock
   repo: tock
   site_source: tock-www
 

--- a/_pages/community.md
+++ b/_pages/community.md
@@ -12,7 +12,7 @@ platforms. We will soon be releasing our primary development platform (based on
 Atmel's SAM4L). Until then, if you want to port Tock to another platform, we
 encourage that and will try to help as much as we can.
 
-The main repository is hosted on [GitHub](https://github.com/helena-project/tock).
+The main repository is hosted on [GitHub](https://github.com/tock/tock).
 
 ## Communication
 

--- a/_pages/documentation/getting-started.md
+++ b/_pages/documentation/getting-started.md
@@ -25,17 +25,17 @@ How would you like to get started?
 
 ### Use Tock
 
-First, follow our [getting started guide](https://github.com/helena-project/tock/blob/master/doc/Getting_Started.md) to setup
+First, follow our [getting started guide](https://github.com/tock/tock/blob/master/doc/Getting_Started.md) to setup
 your system to compile Tock and Tock applications.
 
 Then head to the [hardware page](/hardware)
 to learn about the hardware platforms Tock supports. Also check out the
-[tutorials](https://github.com/helena-project/tock/blob/master/doc/tutorials) to get started running apps with TockOS.
+[tutorials](https://github.com/tock/tock/blob/master/doc/tutorials) to get started running apps with TockOS.
 
 
 ### Develop Tock
 
-Read our [getting started guide](https://github.com/helena-project/tock/blob/master/doc/Getting_Started.md) to get the correct
+Read our [getting started guide](https://github.com/tock/tock/blob/master/doc/Getting_Started.md) to get the correct
 version of the Rust compiler, then look through the `/kernel`, `/capsules`,
 `/chips`, and `/boards` directories.
 
@@ -45,7 +45,7 @@ We're happy to accept pull requests and look forward to seeing how Tock grows.
 ### Learn How Tock Works
 
 Both the design and implementation of Tock are documented in the
-[docs](https://github.com/helena-project/tock/blob/master/doc) folder. Read through the guides there to learn about the kernel,
+[docs](https://github.com/tock/tock/blob/master/doc) folder. Read through the guides there to learn about the kernel,
 Tock's use of Rust, the build system, and applications.
 
 

--- a/_pages/documentation/walkthrough.md
+++ b/_pages/documentation/walkthrough.md
@@ -64,9 +64,9 @@ defining values in the `.vectors`[^vectors] section and relies on the
 board-specific crate[^hail-crate] to place that section appropriately using it's linker
 script:
 
-[^sam4l-crate]: [SAM4L crate](https://github.com/helena-project/tock/tree/master/chips/sam4l)
-[^vectors]: [SAM4L Vector Table](https://github.com/helena-project/tock/blob/master/chips/sam4l/src/lib.rs#L68)
-[^hail-crate]: [Hail Crate](https://github.com/helena-project/tock/tree/master/boards/hail)
+[^sam4l-crate]: [SAM4L crate](https://github.com/tock/tock/tree/master/chips/sam4l)
+[^vectors]: [SAM4L Vector Table](https://github.com/tock/tock/blob/master/chips/sam4l/src/lib.rs#L60)
+[^hail-crate]: [Hail Crate](https://github.com/tock/tock/tree/master/boards/hail)
 
 ```rust
 // Exposed by the linker script or board-specific crate
@@ -217,7 +217,7 @@ while let Some(interrupt) = iq.dequeue() {
 }
 ```
 
-[^service-interrupts]: [`service_pending_interrupts` for SAM4L](https://github.com/helena-project/tock/blob/master/chips/sam4l/src/chip.rs#L70)
+[^service-interrupts]: [`service_pending_interrupts` for SAM4L](https://github.com/tock/tock/blob/master/chips/sam4l/src/chip.rs#L72)
 
 The board definition specifies which system call number is associated with a
 particular capsule in the `with_driver` method[^with-driver]:
@@ -240,7 +240,7 @@ requires them to implement three methods (`allow`, `command`, and `subscribe`)
 corresponding to three of the five system calls processes can invoke. The other
 two (`memop` and `yield`) are handled directly by the scheduler.
 
-[^with-driver]: [`with_driver` for Hail](https://github.com/helena-project/tock/blob/master/boards/hail/src/main.rs#L93)
+[^with-driver]: [`with_driver` for Hail](https://github.com/tock/tock/blob/master/boards/hail/src/main.rs#L81)
 
 ## Process scheduler
 
@@ -346,7 +346,7 @@ fn subscribe(&self, _: usize, callback: Callback) -> isize {
 }
 ```
 
-[^timer-subscribe]: [Timer driver `subscribe`](https://github.com/helena-project/tock/blob/master/capsules/src/alarm.rs#L77)
+[^timer-subscribe]: [Timer driver `subscribe`](https://github.com/tock/tock/blob/master/capsules/src/alarm.rs#L74)
 
 ## Command
 

--- a/_pages/events/sensys2017.md
+++ b/_pages/events/sensys2017.md
@@ -34,7 +34,7 @@ Faculty of Technology, Policy and Management at Jaffalaan 5.
 Please bring a laptop to use during the tutorial and download the
 [Tock VM](http://www.scs.stanford.edu/~alevy/Tock.ova) in advance.
 If you prefer to develop natively, please finish the Tock
-[Getting Started](https://github.com/helena-project/tock/blob/master/doc/Getting_Started.md)
+[Getting Started](https://github.com/tock/tock/blob/master/doc/Getting_Started.md)
 guide so that everything is downloaded in advance.
 
 ## Schedule and Agenda

--- a/_pages/hardware/hail.md
+++ b/_pages/hardware/hail.md
@@ -15,9 +15,9 @@ image: /assets/img/hail_reva_isometric_1000x547.jpg
 [Hail](https://github.com/lab11/hail) is an open source IoT development board
 that supports Tock. It is designed to be a very low-friction way to get started
 using and creating Tock applications. Simply plug in the Hail module over USB
-and use the [tockloader](https://github.com/helena-project/tockloader) utility
+and use the [tockloader](https://github.com/tock/tockloader) utility
 to load and run applications.
-Already have one? Head [here](https://github.com/helena-project/tock/tree/master/boards/hail)
+Already have one? Head [here](https://github.com/tock/tock/tree/master/boards/hail)
 for getting started instructions and to learn how to use your Hail.
 
 {% include hail_buy.html %}
@@ -35,8 +35,8 @@ soldered directly on with the castellations.
 
 ## Tock Support
 
-Hail is [fully supported](https://github.com/helena-project/tock/tree/master/boards/hail)
-by Tock. This includes the [tutorials](https://github.com/helena-project/tock/tree/master/doc/tutorials)
+Hail is [fully supported](https://github.com/tock/tock/tree/master/boards/hail)
+by Tock. This includes the [tutorials](https://github.com/tock/tock/tree/master/doc/tutorials)
 that make it easy to get started with programming Tock applications.
 
 ## Comparison to imix

--- a/_plugins/github_issues.rb
+++ b/_plugins/github_issues.rb
@@ -4,7 +4,7 @@ require 'html/pipeline/hashtag/hashtag_filter'
 
 module Jekyll
   class Issues
-    ISSUE_PREFIX_URL = "https://github.com/helena-project/tock/issues/%{tag}".freeze
+    ISSUE_PREFIX_URL = "https://github.com/tock/tock/issues/%{tag}".freeze
     BODY_START_TAG = "<body".freeze
 
     InvalidJekyllMentionConfig = Class.new(Jekyll::Errors::FatalException)


### PR DESCRIPTION
This patch updates all links to point to the new Github organisation. I did not modify the posts as you might like to preserve them as they are.