### PR TITLE
Change broken links to tutorials to links to "Tock OS Book"

### DIFF
--- a/_pages/documentation/getting-started.md
+++ b/_pages/documentation/getting-started.md
@@ -30,7 +30,7 @@ your system to compile Tock and Tock applications.
 
 Then head to the [hardware page](/hardware)
 to learn about the hardware platforms Tock supports. Also check out the
-[tutorials](https://github.com/tock/tock/blob/master/doc/tutorials) to get started running apps with TockOS.
+[Tock OS Book](https://book.tockos.org/) to get started running apps with TockOS.
 
 
 ### Develop Tock

--- a/_posts/2017-03-23-introducing-hail.md
+++ b/_posts/2017-03-23-introducing-hail.md
@@ -31,7 +31,7 @@ soldered directly on with the castellations.
 ## Tock Support
 
 Hail is [fully supported](https://github.com/helena-project/tock/tree/master/boards/hail)
-by Tock. This includes the [tutorials](https://github.com/helena-project/tock/tree/master/doc/tutorials)
+by Tock. This includes the [Tock OS Book](https://book.tockos.org/)
 that make it easy to get started with programming Tock applications.
 
 ## Comparison to imix


### PR DESCRIPTION
Hello, 

I recently purchased the `Hail` development board, and while browsing the Tock OS website for info, 
I found that some links to the tutorials have been broken.
It seems like the tutorials have now been moved to the **Tock OS Book**, so I made a fix to the two broken links that I found on the website.

Thank you.