### PR TITLE
Make buildable on ubuntu 20.04 to fix netlify deploys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,14 +8,8 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    async (2.2.1)
-      console (~> 1.10)
-      io-event (~> 1.1.0)
-      timers (~> 4.1)
     colorator (1.1.0)
     concurrent-ruby (1.1.10)
-    console (1.16.2)
-      fiber-local
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -23,17 +17,17 @@ GEM
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
     ffi (1.13.1)
-    fiber-local (1.0.0)
     forwardable-extended (2.6.0)
     html-pipeline (2.14.3)
       activesupport (>= 2)
       nokogiri (>= 1.4)
     html-pipeline-hashtag (0.1.2)
       html-pipeline (>= 2.9.1)
-    html-proofer (5.0.0)
+    html-proofer (4.4.3)
       addressable (~> 2.3)
-      async (~> 2.1)
+      mercenary (~> 0.3)
       nokogiri (~> 1.13)
+      parallel (~> 1.10)
       rainbow (~> 3.0)
       typhoeus (~> 1.3)
       yell (~> 2.0)
@@ -41,7 +35,6 @@ GEM
     http_parser.rb (0.6.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    io-event (1.1.2)
     jekyll (4.3.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -84,6 +77,9 @@ GEM
     nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.9-x86_64-linux)
+      racc (~> 1.4)
+    parallel (1.22.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
@@ -99,7 +95,6 @@ GEM
       ffi (~> 1.9)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    timers (4.3.5)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     tzinfo (2.0.5)
@@ -111,6 +106,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   html-pipeline-hashtag
@@ -125,4 +121,4 @@ DEPENDENCIES
   rouge
 
 BUNDLED WITH
-   2.3.9
+   2.3.26


### PR DESCRIPTION
Netlify deploys are broken because netlify deprecated ubuntu 16.04 builds. This PR should fix that -- I pretty much just ran the installation instructions on my ubuntu 20.04 machine. 