### PR TITLE
Add Matrix `.well-know` JSON files

### DIFF
--- a/.well-known/matrix/client
+++ b/.well-known/matrix/client
@@ -1,0 +1,1 @@
+{"m.homeserver":{"base_url":"https://matrix.tockos.org"},"m.identity_server":{"base_url":"https://vector.im"}}

--- a/.well-known/matrix/server
+++ b/.well-known/matrix/server
@@ -1,0 +1,1 @@
+{"m.server":"matrix.tockos.org:443"}

--- a/_config.yml
+++ b/_config.yml
@@ -96,6 +96,7 @@ authors:
 # Build settings
 include:
   - _pages                  # all your pages can be put inside pages (except articles)
+  - .well-known             # include .well-known static content (e.g., for Matrix homeserver discovery)
 exclude:
   - CNAME
   - README.md


### PR DESCRIPTION
These files are required to host a Matrix server under the `tockos.org` domain name. The server does not need to be accessible on this domain (in this case, we chose to use `matrix.tockos.org`), but this allows us to create room addresses like `#general:tockos.org` and user addresses such as `@lschuermann:tockos.org`.