### PR TITLE
Add appropriate CORS & Content-Type headers for Matrix `.well-known`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -97,6 +97,7 @@ authors:
 include:
   - _pages                  # all your pages can be put inside pages (except articles)
   - .well-known             # include .well-known static content (e.g., for Matrix homeserver discovery)
+  - _headers                # Netlify HTTP header configuration
 exclude:
   - CNAME
   - README.md

--- a/_headers
+++ b/_headers
@@ -1,0 +1,6 @@
+# Netlify HTTP headers configuration
+
+# Set the appropriate CORS policy for Matrix:
+/.well-known/matrix/*
+  Content-Type: application/json
+  Access-Control-Allow-Origin: *


### PR DESCRIPTION
This is required for Matrix-clients to be able to resolve the `matrix.tockos.org` homeserver from the `tockos.org` domain.