### PR TITLE
Agenda and tutorial info update

### DIFF
--- a/_pages/cps-iot-2024/agenda.md
+++ b/_pages/cps-iot-2024/agenda.md
@@ -1,0 +1,39 @@
+---
+layout: page
+title:  
+description: Tock CPS-IoT Tutorial Program Agenda - May 13 2024
+permalink: /cps-iot-2024/agenda
+---
+
+# Agenda
+The RUSTIC tutorial will take place on Monday, May 13, 2024 at CPS-IoT Week. The schedule for the event can 
+be found below. Further information on the event can be found [here](https://tockos.org/cps-iot-2024).
+
+## Location
+
+To be announced.
+
+## Schedule
+
+<style type="text/css" scoped>
+.agenda-item {
+//  background-color: #ffdcd9;
+}
+td {
+    text-align: center;
+    padding: 1vw;
+}
+</style>
+
+
+### Monday, May 13, 2024 
+<table style="width: 100%;">
+<tr>
+<th style="width: 15%;">Time</th><th style="width: 85%;">Topic</th></tr>
+<tr class="agenda-item"><td>13:30-14:30</td><td colspan="2">Introduction to Tock</td>
+<tr class="agenda-item"><td>14:30-15:30</td><td colspan="2">Tock Thread Network Application</td>
+<tr class="agenda-item"><td>15:00-15:30</td><td colspan="2">Coffee Break</td>
+<tr class="agenda-item"><td>15:30-16:30</td><td colspan="2">Tock Thread Network Cont.</td>
+<tr class="agenda-item"><td>16:30-17:00</td><td colspan="2">Tock Multi-tenancy and Robustness</td>
+<tr class="agenda-item"><td>17:00-17:30</td><td colspan="2">Next Steps and Future Directions with Tock</td>
+</tr>

--- a/_pages/cps-iot-2024/index.md
+++ b/_pages/cps-iot-2024/index.md
@@ -7,13 +7,24 @@ permalink: /cps-iot-2024
 
 ## Rapid Prototyping for Cyber-Physical Systems and IoT Applications with the Tock Embedded Operating System
 
-We will be holding a half-day tutorial at [CPS-IoT Week](https://cps-iot-week2024.ie.cuhk.edu.hk/index.php) on the Tock Operating System.
+We will be holding a half-day tutorial at [CPS-IoT Week](https://cps-iot-week2024.ie.cuhk.edu.hk/index.php) on the Tock Operating System. This tutorial will take place on Monday, May 13, 2024 ([agenda](https://tockos.org/cps-iot-2024/agenda)).
 
-Tock is a secure, multi-programmable embedded operating system. The core kernel is written in Rust, a new type-safe systems language. Developers can dynamically load processes written in any language, which Tock isolates using the memory protection unit (MPU) or equivalent hardware typically available on microcontroller-class devices. Tock is designed and implemented by collaborators at Stanford, University of Virginia, Princeton, and UC San Diego, with additional developers at Chalmers, Google, Western Digital, HP Labs, MIT, NASA Ames, and others in industry. 
+## Who is this tutorial for?
+
+This tutorial is for researchers and industry stakeholders interested in any combination of embedded operating systems, wireless sensor networking, IoT, Rust, or simply hacking on a project for an afternoon. We assume no prior knowledge in Tock and will provide a detailed guide to assist participants in the tutorial.
+
+## What is Tock?
+
+Tock is a secure, multi-programmable embedded operating system. The core kernel is written in Rust, a new type-safe systems language. Developers can dynamically load processes written in any language, which Tock isolates using the memory protection unit (MPU) or equivalent hardware typically available on microcontroller-class devices. Tock is designed and implemented by collaborators at Stanford, University of Virginia, Princeton, and UC San Diego, with additional developers at Chalmers, Google, Western Digital, HP Labs, MIT, NASA Ames, and others in industry. To learn more about our operating system, you can find additional documentation both [here](https://tockos.org/documentation) or in the [tock book](https://book.tockos.org).
+
+## Tutorial Goals
 
 The goal of the tutorial is to introduce the OS to researchers in the CPS-IoT community, get them started writing applications, and make them familiar with the kernel. The tutorial will provide small hardware kits (further nodes supported by Tock can be purchased online). The emphasis of the tutorial will be for Tock’s potential as a platform for easing, accelerating, and enhancing research and prototyping of CPS and IoT systems and applications.
 
-Sensor network and IoT research has seen a significant increase in the past few years, as evidenced by the larger number of submissions to CPS-IoT week as well as sister venues such as SenSys and EWSN in recent years, as well as pronounced industrial interest in more capable embedded devices. We believe that having a modern, secure OS platform has the
-potential to help coalesce the community around a set of shared important research problems. We think Tock has the potential to be such an OS/platform and would like to provide a tutorial to help colleagues and fellow researchers in learning to use it. 
+Tock provides a unique advantage for CPS and IoT research as the operating system by default provides process isolation and memory safety for the core kernel. As such, researchers can spend more time on CPS and IoT research rather than time spent configuring the MPU or radio drivers. Moreover, the Tock kernel provides the advantages of a modern type-safe language while still providing the freedom to develop user applications in C.
 
-Please check this page for futher information and updates as we approach the conference!
+Having a modern, secure OS platform has the potential to help coalesce the CPS-IoT community around a set of shared important research problems. We think Tock has the potential to be such an OS/platform and would like to provide a tutorial to help colleagues and fellow researchers in learning to use it. 
+
+## Tutorial Overview
+
+In this tutorial, participants will create a wireless sensor network application using Tock and [OpenThread](https://openthread.io). To participate in this tutorial, please register for the RUSTIC tutorial. We will provide participants with additional instructions and details as we approach the conference.


### PR DESCRIPTION
This adds the agenda for CPS-IoT and a more detailed landing page. 

A few things for consideration:

-I followed the TockWorld agenda table format. I used the `vw` css element so the padding should scale with mobile (and tested how it looks with the firefox responsive design feature). Please let me know if there are thoughts on this.
-Confirm added text to landing page.
-Should we add more for the overview?