### PR TITLE
feed.xml: site.name → site.title

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -4,7 +4,7 @@ layout: null
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
-    <title>{{ site.name | xml_escape }}</title>
+    <title>{{ site.title | xml_escape }}</title>
     <description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>
     <link>{{ site.url }}{{ site.baseurl }}</link>
     <atom:link href="{{ site.baseurl | prepend: site.url }}/feed.xml" rel="self" type="application/rss+xml" />


### PR DESCRIPTION
`site.name` is undefined, which results in `<title />`, which results in URL instead of nice page title in RSS readers