### PR TITLE
Fix mobile navigation and layout issues

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -31,7 +31,9 @@ body > header {
   box-sizing: border-box;
   background-color: white;
   border-bottom: 2px solid #f5f5f5;
-  display: block;
+  display: flex;
+  justify-content: space-between;
+
   @media screen and (min-width: $tablet) {
     display: flex;
     flex-direction: row;
@@ -108,7 +110,8 @@ body > header {
 
   @media screen and (max-width: $tablet) {
     > nav {
-      float: right;
+      position: relative;
+      z-index: 10;
 
       .hamburger {
         i {
@@ -121,6 +124,19 @@ body > header {
 
       ul {
         display: none;
+        background-color: white;
+        box-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
+        padding: 5px;
+      }
+
+      ul li:not(:last-child) {
+        border-bottom: 1px solid $divider-color;
+      }
+
+      ul li a {
+        display: flex;
+        flex-direction: row-reverse;
+        margin-left: 0px;
       }
 
       i.menu {
@@ -137,6 +153,7 @@ body > header {
         }
         & ~ i.close {
           display: block;
+          margin-top: 8px;
         }
 
         & ~ i.menu {
@@ -178,14 +195,29 @@ footer {
     max-width: 800px;
     margin: 0 auto;
     display: flex;
+
+    @media screen and (max-width: $tablet) {
+      flex-direction: column;
+      padding: 0 $spacer;
+    }
+
     div {
       flex: 1;
       margin: auto 0;
       text-align: left;
+      
+      @media screen and (max-width: $tablet) {
+        margin: $spacer 0;
+        text-align: center;
+      }
     }
 
     div:nth-child(2) {
       text-align: right;
+      
+      @media screen and (max-width: $tablet) {
+        text-align: center;
+      }
     }
 
     img {
@@ -194,6 +226,13 @@ footer {
 
     ul {
       display: block;
+      
+      @media screen and (max-width: $tablet) {
+        margin-top: $spacer;
+        list-style-type: none;
+        padding-left: 0;
+      }
+      
       li {
         display: inline;
       }

--- a/assets/css/landing.scss
+++ b/assets/css/landing.scss
@@ -90,9 +90,14 @@ ul#applications {
     flex-wrap: wrap;
     list-style: none;
     padding: 2 * $spacer;
+
     @media screen and (min-width: $tablet) {
       padding-left: 140px;
       padding-right: 140px;
+    }
+
+    @media screen and (max-width: $tablet) {
+      font-size: 1.5rem;
     }
 
     font-size: 2rem;
@@ -127,12 +132,16 @@ ul#applications {
   }
 
   li:nth-child(even) {
-    flex-direction: row-reverse;
     background-color: $primary-color;
     color: white;
-    div:first-child {
-      flex: 1;
-      margin-left: 3 * $spacer;
+  }
+  @media screen and (min-width: $tablet) {
+    li:nth-child(even) {
+      flex-direction: row-reverse;
+      div:first-child {
+        flex: 1;
+        margin-left: 3 * $spacer;
+      }
     }
   }
 }


### PR DESCRIPTION
I noticed tock had a 2.2 release which is exciting, but when I went to the website on my phone I couldn't make it to the hardware page due to the hero div overlaying the navigation menu (see attached images), this PR aims to fix this and some overflow issues I noticed on mobile.

- Fix hamburger menu visibility by converting to overlay layout, now the hamburger menu won't be hidden behind the hero div

Before (page is cut off as you have to scroll to the right to make it to the menu): 
![image](https://github.com/user-attachments/assets/5ae2b613-7c17-48f9-b693-87222738b36a)

After (menu works, x overflow fixed):
![image](https://github.com/user-attachments/assets/c57e1fee-6806-4789-9a96-51eeddaff2d7)

- Vertically align hamburger menu button with logo
- Resolve footer overflow on mobile by switching to column layout on tablet/mobile breakpoints
- Adjust landing page application section font size for mobile, it was causing the page to overflow and scroll
- Fix a layout issue on the application section, the "Security critical devices" div is offset on desktop for its preview image, but on mobile these images are hidden

Note: Some pages may still overflow on mobile (e.g., hardware), this can be addressed in the future

Desktop experience remains unchanged