### PR TITLE
closes 139. markdown for awesome community page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,25 +11,40 @@
 Dependencies:
 
 First install ruby and ruby bundler if you don't already have it from another ruby project:
-
+```bash
     sudo apt install ruby ruby-dev
+```
+
+To configure RubyGems to install executables in your user account rather than in a system directory add these lines to ~/.bashrc on Linux or ~/.zshrc on macOS:
+```bash
+    export GEM_HOME="$HOME/gems"
+    export PATH="$GEM_HOME/bin:$PATH"
+```
+Restart your shell, or load the updated file (for example, source ~/.bashrc). Then install Bundler without sudo:
+```
     gem install jekyll bundler
+```
 
 or
 
+```bash
     # Note: No sudo on a Mac. You should never use sudo for these kinds of installs on a Mac anymore.
     # sudo may make this work for now, but it will make your life miserable in the long run.
+
     brew install ruby
     gem install jekyll bundler
+```
+
 
 Then use bundler to install the needed gems
-
+```bash
     bundle install
+```
 
 To build the website:
-
+```bash
     bundle exec jekyll serve
-
+```
 Now browse to http://localhost:4000 to view
 
 Logo maker: [logomakr.com/5mGstw](https://logomakr.com/5mGstw)

--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,9 @@ navigation:
   - title: Community
     url: /community/
     description: Mailing list, GitHub, IRC...
+  - title: Awesome Tock
+    url: /awesome/
+    description: Community projects built with and around Tock
   - title: Papers
     url: /papers/
     description: Published academic papers about Tock

--- a/_pages/awesome.md
+++ b/_pages/awesome.md
@@ -1,0 +1,80 @@
+---
+layout: page
+title: Awesome Tock
+description: Community projects built with and around the Tock embedded operating system
+permalink: /awesome/
+---
+
+Tock is more than a kernel. This is a curated list of independently developed
+products, ports, applications, tools, and research from across the Tock
+community. Projects within each category are listed alphabetically, not by
+preference.
+
+## Systems and deployments
+
+Products and real-world systems that put Tock to work.
+
+  * [Signpost](https://github.com/lab11/signpost) is a modular, city-scale
+    sensing platform that uses Tock to safely run independent sensing
+    applications in the field.
+  * [SmartClip](https://github.com/Samir-Rashid/smartclip) is an open-source,
+    low-power wearable computing testbed that supports Tock and the Thread
+    protocol.
+  * [Tock on Titan](https://github.com/google/tock-on-titan) contains Google's
+    ports of Tock to the embedded controllers used in the Titan security
+    ecosystem (this repository is now read only).
+
+## Hardware and board ports
+
+Community support for running Tock on more chips and boards.
+
+  * [OpenSK HiFive](https://github.com/ljrk0/OpenSK_HiFive) is an initial port
+    of the OpenSK and Tock security-key firmware to the RISC-V SiFive HiFive
+    platform.
+  * [Out-of-tree Tock for Raspberry Pi Pico](https://github.com/potto216/tockos_oot_raspberry_pi_pico)
+    provides a standalone Raspberry Pi Pico board and RP2040 chip crate,
+    including userspace SPI support and direct UART support.
+
+## Applications and experiments
+
+Things to run, learn from, take apart, and build on.
+
+  * [Retro Platformer for Tock](https://github.com/seanflynn1107/retro-platformer-tock)
+    is a 2D platform game written in C for Tock on the nRF52840 DK with an
+    SH1106 OLED display.
+  * [Tock DSP](https://github.com/mdclyburn/tock-dsp) explores audio digital
+    signal processing on Tock (This is an incompatible fork of the Tock OS project).
+  * [Tock Ping](https://github.com/mog96/tock-ping) is a Linux bridge for
+    testing Tock's 6LoWPAN and IEEE 802.15.4 stack with IPv6 traffic.
+
+## Developer tools
+
+Community utilities that make developing and testing Tock easier.
+
+  * [Tock Configurator](https://github.com/OxidosAutomotive/tock-configurator)
+    is a Rust-based tool for configuring Tock for supported boards.
+  * [Tock Docker](https://github.com/george-hopkins/tock-docker) provides a
+    containerized environment for getting a Tock development toolchain up and
+    running.
+  * [Tock Test Harness](https://github.com/goodoomoodoo/tock-test-harness) is a
+    test runner for exercising Tock systems.
+
+## Research and verification
+
+Projects examining, extending, and reasoning about Tock's design.
+
+  * [Lightweight Tock Verification](https://github.com/Samir-Rashid/osfc24-tockos-lightweight-verification)
+    contains artifacts for exploring lightweight firmware verification with
+    Tock.
+  * [Omniglot Tock](https://github.com/omniglot-rs/omniglot-tock) is a RISC-V
+    PMP-based Tock runtime for the Omniglot project.
+  * [Tock Veri-ASM](https://github.com/PLSysSec/tock-veri-asm) contains
+    research code for reasoning about inline assembly in Tock.
+
+## Contributing
+
+We welcome source-available community work that helps people understand, use,
+or extend Tock. A project can be established or experimental, as long as its
+description makes that clear. If something is missing or out of date, please
+[open an issue](https://github.com/tock/tock-www/issues/new) or
+[send a pull request](https://github.com/tock/tock-www).


### PR DESCRIPTION
The purpose of this PR is to add an "Awesome Tock" page to share community projects on tockos.org. 

I used OpenAI's codex to help complete the issue. I personally verified the links. I updated the readme to include information on setting up the gems in the user home directory because I ran into issues when trying to do that system wide on Ubuntu 24.04.

I also had Codex perform a security audit of the patch and it did not find any security vulnerabilities (report below).

No security vulnerabilities found in `awesome_page_update.patch`.

The patch:

- Adds only static Markdown and YAML.
- Introduces no JavaScript, raw HTML, event handlers, templating expressions, or user-controlled rendering.
- Uses HTTPS for every external project link.
- Uses plain internal navigation for `/awesome/`.
- Does not modify dependencies or `Gemfile.lock`.

The `http://localhost:4000` README URL is local development traffic and not a concern. Prepending `$HOME/gems/bin` to `PATH` is standard user-scoped Ruby configuration; it assumes normal home-directory permissions.

Residual operational risk: the page links to independently maintained repositories, so inclusion should not imply that Tock has security-audited their code. Periodic link and ownership review would be prudent, but this is not a patch vulnerability.

`git diff --check` and reverse patch validation passed. No files were modified during the review.